### PR TITLE
Raise FileNotFoundError if file was not found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--py37-plus", "--keep-runtime-typing"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/src/himena/plugins/io.py
+++ b/src/himena/plugins/io.py
@@ -87,9 +87,17 @@ class ReaderPlugin(_IOPluginBase):
     def read(self, path: Path | list[Path]) -> WidgetDataModel:
         """Read file(s) and return a data model."""
         if isinstance(path, list):
-            out = self._func([Path(p) for p in path])
+            paths: list[Path] = []
+            for p in path:
+                if not p.exists():
+                    raise FileNotFoundError(f"File {p!r} does not exist.")
+                paths.append(p)
+            out = self._func(paths)
         else:
-            out = self._func(Path(path))
+            path = Path(path)
+            if not path.exists():
+                raise FileNotFoundError(f"File {path!r} does not exist.")
+            out = self._func(path)
         if not isinstance(out, WidgetDataModel):
             raise TypeError(f"Reader plugin {self!r} did not return a WidgetDataModel.")
         return out


### PR DESCRIPTION
When `ui.read_file` tries to read a file that does not exist, it creates a widget for reader-not-found type.
This PR fix this.