### PR TITLE
Implement `create_model` for type inferring and better signature

### DIFF
--- a/src/himena/__init__.py
+++ b/src/himena/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.0.7"
 __author__ = "Hanjin Liu"
 
-from himena.core import new_window
+from himena.core import new_window, create_model
 from himena.consts import StandardType
 from himena.widgets import MainWindow
 from himena.types import WidgetDataModel, ClipboardDataModel, Parametric
@@ -9,6 +9,7 @@ from himena._app_model import AppContext
 
 __all__ = [
     "new_window",
+    "create_model",
     "StandardType",
     "MainWindow",
     "WidgetDataModel",

--- a/src/himena/core.py
+++ b/src/himena/core.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence, TypeVar
 from logging import getLogger
+from himena.consts import StandardType
+from himena.types import WidgetDataModel
+from himena.standards import BaseMetadata
 from himena.profile import AppProfile, load_app_profile
 
 if TYPE_CHECKING:
     from himena.widgets import MainWindow
 
 _LOGGER = getLogger(__name__)
+_T = TypeVar("_T")
 
 
 def new_window(
@@ -57,6 +61,35 @@ def new_window(
         for cmd, kwargs, exc in exceptions:
             _LOGGER.error("  %r (parameters=%r): %s", cmd, kwargs, exc)
     return main_window
+
+
+def create_model(
+    value: _T,
+    *,
+    type: str | None = None,
+    title: str | None = None,
+    extension_default: str | None = None,
+    extensions: list[str] | None = None,
+    metadata: object | None = None,
+    force_open_with: str | None = None,
+    editable: bool = True,
+) -> WidgetDataModel[_T]:
+    """Helper function to create a WidgetDataModel."""
+    if type is None:
+        if isinstance(metadata, BaseMetadata):
+            type = metadata.expected_type()
+    if type is None:
+        type = StandardType.ANY
+    return WidgetDataModel(
+        value=value,
+        type=type,
+        title=title,
+        extension_default=extension_default,
+        extensions=extensions or [],
+        metadata=metadata,
+        force_open_with=force_open_with,
+        editable=editable,
+    )
 
 
 def _get_main_window(backend: str, *args, **kwargs) -> MainWindow:

--- a/src/himena/session/_api.py
+++ b/src/himena/session/_api.py
@@ -12,7 +12,7 @@ from himena.session._utils import (
     write_metadata_by_title,
     replace_invalid_characters,
 )
-from himena.standards.model_meta import read_metadata
+from himena.standards import read_metadata
 from himena.widgets._wrapper import ParametricWindow
 from himena.workflow import LocalReaderMethod
 from himena.workflow._command import CommandExecution

--- a/src/himena/session/_session.py
+++ b/src/himena/session/_session.py
@@ -14,7 +14,7 @@ from himena.utils.misc import is_subtype
 from himena import anchor
 from himena._providers import ReaderStore
 from himena.widgets._wrapper import ParametricWindow
-from himena.standards.model_meta import read_metadata
+from himena.standards import read_metadata
 from himena.workflow import Workflow, compute, WorkflowStepType, LocalReaderMethod
 
 if TYPE_CHECKING:

--- a/src/himena/session/_utils.py
+++ b/src/himena/session/_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from himena import io_utils
-from himena.standards.model_meta import BaseMetadata, write_metadata
+from himena.standards import BaseMetadata, write_metadata
 from himena.types import WidgetDataModel
 from himena.widgets import SubWindow
 import re

--- a/src/himena/standards/__init__.py
+++ b/src/himena/standards/__init__.py
@@ -1,0 +1,3 @@
+from himena.standards._base import BaseMetadata, read_metadata, write_metadata
+
+__all__ = ["BaseMetadata", "read_metadata", "write_metadata"]

--- a/src/himena/standards/_base.py
+++ b/src/himena/standards/_base.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from pydantic_compat import BaseModel
+from himena.utils.misc import iter_subclasses
+
+if TYPE_CHECKING:
+    from typing import Self
+
+_META_NAME = "meta.json"
+_CLASS_JSON = ".class.json"
+
+
+class BaseMetadata(BaseModel):
+    """The base class for a model metadata."""
+
+    @classmethod
+    def from_metadata(cls, dir_path: Path) -> "Self":
+        """Construct the metadata from a directory."""
+        return cls.model_validate_json(dir_path.joinpath(_META_NAME).read_text())
+
+    def write_metadata(self, dir_path: Path) -> None:
+        """Write the metadata to a directory."""
+        dir_path.joinpath(_META_NAME).write_text(self.model_dump_json())
+
+    def expected_type(self) -> str | None:
+        """Return the expected type of the metadata. None if not applicable."""
+        return None
+
+    def _class_info(self) -> dict:
+        return {"name": self.__class__.__name__, "module": self.__class__.__module__}
+
+    def _repr_pretty_(self, p, cycle):
+        """Pretty print the metadata."""
+        lines = [f"{self.__class__.__name__}("]
+        for key, value in self.__repr_args__():
+            lines.append(f"  {key}={value!r},")
+        lines.append(")")
+        p.text("\n".join(lines))
+
+
+def read_metadata(dir_path: Path) -> BaseMetadata:
+    """Read the metadata from a directory."""
+    with dir_path.joinpath(_CLASS_JSON).open("r") as f:
+        class_js = json.load(f)
+    module = class_js["module"]
+    name = class_js["name"]
+    for sub in iter_subclasses(BaseMetadata):
+        if sub.__name__ == name and sub.__module__ == module:
+            metadata_class = sub
+            break
+    else:
+        raise ValueError(f"Metadata class {name=}n {module=} not found.")
+
+    return metadata_class.from_metadata(dir_path)
+
+
+def write_metadata(meta: BaseMetadata, dir_path: Path) -> None:
+    """Write the metadata to a directory."""
+    meta.write_metadata(dir_path)
+    with dir_path.joinpath(_CLASS_JSON).open("w") as f:
+        json.dump(meta._class_info(), f)
+    return None

--- a/src/himena_builtins/tools/dataframe.py
+++ b/src/himena_builtins/tools/dataframe.py
@@ -3,6 +3,7 @@ from himena.standards.model_meta import TableMeta
 from himena.plugins import register_function, configure_gui
 from himena.types import WidgetDataModel, Parametric
 from himena.consts import StandardType, MenuId
+from himena.core import create_model
 
 
 @register_function(
@@ -41,11 +42,8 @@ def series_as_array(model: WidgetDataModel) -> Parametric:
 
     @configure_gui(column={"bind": _get_column_index})
     def run_series_as_array(column: str):
-        df = wrap_dataframe(model.value)
-        series = df.column_to_array(column)
-
-        return WidgetDataModel(
-            value=series,
+        return create_model(
+            wrap_dataframe(model.value).column_to_array(column),
             title=f"{model.title} ({column})",
             type=StandardType.ARRAY,
             extension_default=".npy",

--- a/src/himena_builtins/tools/dict.py
+++ b/src/himena_builtins/tools/dict.py
@@ -3,6 +3,7 @@ from himena.standards.model_meta import DictMeta
 from himena.plugins import register_function
 from himena.types import WidgetDataModel
 from himena.consts import StandardType, MenuId
+from himena.core import create_model
 
 if TYPE_CHECKING:
     import numpy as np
@@ -23,8 +24,8 @@ def duplicate_this_tab(
         type_out = model.type[5:]
     else:
         type_out = model.type
-    return WidgetDataModel(
-        value=model.value[tab],
+    return create_model(
+        model.value[tab],
         title=f"{model.title} ({tab})",
         type=type_out,
         extension_default=".csv",


### PR DESCRIPTION
Using `create_model` instead of `WidgetDataModel` to improve readability, signature and type inference from metadata.