### PR TITLE
Add border to tooltip

### DIFF
--- a/src/himena/__init__.py
+++ b/src/himena/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "Hanjin Liu"
 
 from typing import TYPE_CHECKING

--- a/src/himena/qt/style.qss
+++ b/src/himena/qt/style.qss
@@ -498,6 +498,7 @@ QToolTip {
     background-color: #[background];
     color: #[foreground];
     padding: 1px;
+    border: 1px solid gray;
     border-radius: 2px;
 }
 


### PR DESCRIPTION
The shadow effect is not applied in Ubuntu (and probably in other OS as well). This PR updates the stylesheet for QToolTip to show border.